### PR TITLE
browse queries fix

### DIFF
--- a/_data/config-browse.csv
+++ b/_data/config-browse.csv
@@ -1,7 +1,5 @@
 field,display_name,btn,hidden,sort_name,facet_name,values
 title,Title,,true,,,
-subject,Subjects,,true,,,
-description,Description,,true,,,
 film,,,,Film,Film,Licorice Pizza|Phantom Thread|Punch-Drunk Love
 timestamp,,,,,,
 angle,,,true,,Camera Angle,overhead|high|low|eye-level|dutch|point of view

--- a/_includes/js/browse-js.html
+++ b/_includes/js/browse-js.html
@@ -1067,37 +1067,61 @@ function setupEventHandlers() {
     function addQuery(field, value){ 
         // get page url
         let currentUrl = window.location.href;
-        let fixedUrl = currentUrl.replace('http://127.0.0.1:4000/', '');
-        // get string that needs to be appended to url based on button clicked 
-        // find what the number of the new query should be
+        let startQuery = currentUrl.replace('{{ site.url | append: site.baseurl | append: page.url }}', '').replace('http://127.0.0.1:4000/pt-annotated/browse.html', '');
+        // check if a filter with this value has already been applied and remove it
+        if (startQuery.includes(value.replaceAll(' ','+'))) {
+            // search current url for full query string
+            let pattern = new RegExp(String.raw`\Wb\d?=\w{2,3}\Wf\d?=${field.replaceAll(' ','\\+')}\Wv\d?=${value.replaceAll(' ','\\+')}`);
+            console.log(pattern);
+            let oldQuery = startQuery.match(pattern)[0];
+            // remove old query from the url
+            startQuery = startQuery.replace(oldQuery, '');
+            // fix numbers on other queries
+            let deletedQueryNum = oldQuery.match(/\d/)[0];
+            for (let i = deletedQueryNum; i < 99; i++) {
+                if (startQuery.includes(i.toString())) {
+                    let newNum = i - 1;
+                    startQuery = startQuery.replaceAll(i.toString(), newNum.toString());
+                } else {
+                    break;
+                }
+            }
+        }
+        // find what the number of the new filter should be
         for (let i = 0; i < 99; i++) {
-            if (fixedUrl.includes(i.toString())) {
+            if (startQuery.includes(i.toString())) {
                 continue;
             } else {
-                var queryNum = i.toString();
+                var filterNum = i.toString();
                 break;
             }
         }
-        // check if this is the first query
+        // if this is the first filter, start with ?; if not, start with &
         let stringStart = '';
-        if (queryNum == '0'){
+        if (filterNum == '0'){
             stringStart = '?';
         } else {
             stringStart = '&';
         }
-        // get the value of the boolean operator for this query
+        // get the value of the boolean operator for this filter
         let boolId = field.toLowerCase().replaceAll(' ', '-') + '-' + value.toLowerCase().replaceAll(' ', '-') + '-boolean';
-        console.log(boolId);
+        // console.log(boolId);
         let boolValue = document.getElementById(boolId).value;
-        // assemble the parts of the query string
-        let boolString = 'b' + queryNum + '=' + boolValue;
-        let fieldString = 'f' + queryNum + '=' + field;
-        let valueString = 'v' + queryNum + '=' + value;
-        let newQuery =  stringStart + boolString + '&' + fieldString + '&' + valueString.replaceAll(' ','+');
-        // append the query string to the url
-        let newUrl = currentUrl + newQuery;
-        // fix double ??, in case the original url had a ? at the end already
-        newUrl = newUrl.replace('??', '?');
+        // assemble the parts of the filter string
+        let boolString = 'b' + filterNum + '=' + boolValue;
+        let fieldString = 'f' + filterNum + '=' + field;
+        let valueString = 'v' + filterNum + '=' + value;
+        let newFilter =  stringStart + boolString + '&' + fieldString + '&' + valueString.replaceAll(' ','+');
+        // append the filter string to the query
+        let newQuery = startQuery + newFilter;
+        // ensure first character of whole query is ? not &
+        if (newQuery[0] == '&') {
+            newQuery = newQuery.replace('&', '?');
+        }
+        // fix double ?? at start of query
+        newQuery = newQuery.replace('??', '?');
+        var newUrl = '{{ site.url | append: site.baseurl | append: page.url }}' + newQuery;
+        console.log(newUrl);
         window.location.href = newUrl;
     }
 </script>

--- a/_includes/js/cloud-js.html
+++ b/_includes/js/cloud-js.html
@@ -16,8 +16,9 @@
 {%- comment -%} capture terms from all cloud fields {%- endcomment -%}
 {%- assign terms = "" -%}
 {%- for c in cloud-fields -%}
-{% assign new = items | map: c | join: ";" %}
-{% assign terms = terms | append: ";" | append: new %}
+{% assign new = items | map: c | compact | join: ";" | split: ";" %}
+{% capture field_terms %}{% for n in new %}{{n}}~{{c}};{% endfor %}{% endcapture %}
+{% assign terms = terms | append: ";" | append: field_terms %}
 {%- endfor -%}
 {%- comment -%} find unique terms and counts {%- endcomment -%}
 {%- assign uniqTerms = terms | downcase | split: ";" | array_count_uniq | sort | where_exp: 't','t[1] >= termsMin' -%}
@@ -26,7 +27,7 @@
 (function(){    
     /* subject terms + count */
     var terms = [
-        {% for t in uniqTerms %}[{{ t[0] | jsonify }}, {{ t[1] | jsonify }}]{% unless forloop.last %}, {% endunless %}{% endfor %}
+        {% for t in uniqTerms %}{% assign term_field = t[0] | split: "~" %}[{{ term_field[0] | jsonify }}, {{ t[1] | jsonify }},{{term_field[1] | jsonify}}]{% unless forloop.last %}, {% endunless %}{% endfor %}
     ];
 
     {% if include.stopwords %}/* apply stopwords */
@@ -57,10 +58,10 @@
         var items = "";
         {% if include.shuffle == true %}shuffle(array);{% endif %}
         var colors = ["primary", "success", "info", "warning", "danger"];
-        for (i = 0; i < array.length; i++) {
+        for (let i = 0; i < array.length; i++) {
             size = mapSize(array[i][1]);
             var randomColor = colors[Math.floor(Math.random() * colors.length)];
-            items += '<a class="btn btn-' + randomColor + ' m-2 tagcloud' + size + '" href="{{ "/browse.html" | relative_url }}#' + encodeURIComponent(array[i][0]) + '" >' + array[i][0] + '</a>';
+            items += '<a class="btn btn-' + randomColor + ' m-2 tagcloud' + size + '" href="{{ "/browse.html" | relative_url }}' + '?b0=AND&f0=' + array[i][2] + '&v0=' + encodeURIComponent(array[i][0]) + '" >' + array[i][0] + '</a>';
         }
         cloud.innerHTML = items;
     }


### PR DESCRIPTION
- fix queries on tagcloud links
- fix behavior when a new filter is applied and one that affects the same value was already applied
  - e.g. "AND angle:high" is already applied and the user applies "OR angle:high"; now the old "AND angle:high" is removed, the numbers of all other applied queries are shifted accordingly, and the new "OR angle:high" filter is added
- removed unused metadata fields on browse page (for now)