### PR TITLE
Fixed empty spaces following links on mobile to include the external …

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -229,9 +229,40 @@ a:hover svg {
 }
 
 .external-link-icon {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
     transform: scale(0.8);
     vertical-align: 0;
 }
+
+/* Hide auto-injected SVG icons */
+/*This section of code can be deleted if there is another way to get rid of the automatic external link items other than hiding them*/
+a[target="_blank"] svg.bi,
+a[target="_blank"] svg.icon-sprite,
+a[target="_blank"] svg.external-link-icon {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+/* Add external link icon to all external links (works on mobile and PC)*/
+a[target="_blank"]::after {
+  content: "";
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  margin-left: 2px;
+  background-color: currentColor;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0z'/%3E%3C/svg%3E");
+}
+
 
 /* Accessibility Utility */
 .visually-hidden {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -229,9 +229,6 @@ a:hover svg {
 }
 
 .external-link-icon {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
     transform: scale(0.8);
     vertical-align: 0;
 }


### PR DESCRIPTION
…link icon

# Pull request

## Proposed changes

On mobile the external link icon was not appearing due to it not supporting the <use> command. This fix adds to the custom scss to add a icon that is more supported and also the hide the icon that CollectionBuilder automatically puts in.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
