### PR TITLE
Adding custom css so that popup on compound objects page fits rest of…

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -994,3 +994,11 @@ a[target="_blank"]::after {
   }
 
 } 
+
+/* ------------
+    Compound Objects Page
+   ------------ */
+
+   .modal-content {
+    background-color: #000;
+   }


### PR DESCRIPTION
… site theme

# Pull request

## Proposed changes

Making background of modal popup on compound page black so that it fits in with rest of site theming

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [x ] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
